### PR TITLE
varint tests

### DIFF
--- a/src/varint.rs
+++ b/src/varint.rs
@@ -84,32 +84,27 @@ mod tests {
   }
 
   #[test]
-  fn decoding_bip_samples() {
-    assert_eq!(decode(&[0x00]), Ok((0, 1)));
-    assert_eq!(decode(&[0x01]), Ok((1, 1)));
-    assert_eq!(decode(&[0x7F]), Ok((127, 1)));
-    assert_eq!(decode(&[0x80, 0x00]), Ok((128, 2)));
-    assert_eq!(decode(&[0x80, 0x7F]), Ok((255, 2)));
-    assert_eq!(decode(&[0x81, 0x00]), Ok((256, 2)));
-    assert_eq!(decode(&[0xFE, 0x7F]), Ok((16383, 2)));
-    assert_eq!(decode(&[0xFF, 0x00]), Ok((16384, 2)));
-    assert_eq!(decode(&[0xFF, 0x7F]), Ok((16511, 2)));
-    assert_eq!(decode(&[0x82, 0xFE, 0x7F]), Ok((65535, 3)));
-    assert_eq!(decode(&[0x8E, 0xFE, 0xFE, 0xFF, 0x00, ]), Ok((1 << 32, 5)));
-  }
+  fn taproot_annex_format_bip_test_vectors_round_trip_successfully() {
+    const TEST_VECTORS: &[(u128, &[u8])] = &[
+      (0, &[0x00]),
+      (1, &[0x01]),
+      (127, &[0x7F]),
+      (128, &[0x80, 0x00]),
+      (255, &[0x80, 0x7F]),
+      (256, &[0x81, 0x00]),
+      (16383, &[0xFE, 0x7F]),
+      (16384, &[0xFF, 0x00]),
+      (16511, &[0xFF, 0x7F]),
+      (65535, &[0x82, 0xFE, 0x7F]),
+      (1 << 32, &[0x8E, 0xFE, 0xFE, 0xFF, 0x00]),
+    ];
 
-  #[test]
-  fn encoding_bip_samples() {
-    assert_eq!(encode(0), &[0x00]);
-    assert_eq!(encode(1), &[0x01]);
-    assert_eq!(encode(127), &[0x7F]);
-    assert_eq!(encode(128), &[0x80, 0x00]);
-    assert_eq!(encode(255), &[0x80, 0x7F]);
-    assert_eq!(encode(256), &[0x81, 0x00]);
-    assert_eq!(encode(16383), &[0xFE, 0x7F]);
-    assert_eq!(encode(16384), &[0xFF, 0x00]);
-    assert_eq!(encode(16511), &[0xFF, 0x7F]);
-    assert_eq!(encode(65535), &[0x82, 0xFE, 0x7F]);
-    assert_eq!(encode(1 << 32), &[0x8E, 0xFE, 0xFE, 0xFF, 0x00, ]);
+    for (n, encoding) in TEST_VECTORS {
+      let actual = encode(*n);
+      assert_eq!(actual, *encoding);
+      let (actual, length) = decode(encoding).unwrap();
+      assert_eq!(actual, *n);
+      assert_eq!(length, encoding.len());
+    }
   }
 }

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -82,4 +82,34 @@ mod tests {
       Err(Error::Varint)
     );
   }
+
+  #[test]
+  fn decoding_bip_samples() {
+    assert_eq!(decode(&[0x00]), Ok((0, 1)));
+    assert_eq!(decode(&[0x01]), Ok((1, 1)));
+    assert_eq!(decode(&[0x7F]), Ok((127, 1)));
+    assert_eq!(decode(&[0x80, 0x00]), Ok((128, 2)));
+    assert_eq!(decode(&[0x80, 0x7F]), Ok((255, 2)));
+    assert_eq!(decode(&[0x81, 0x00]), Ok((256, 2)));
+    assert_eq!(decode(&[0xFE, 0x7F]), Ok((16383, 2)));
+    assert_eq!(decode(&[0xFF, 0x00]), Ok((16384, 2)));
+    assert_eq!(decode(&[0xFF, 0x7F]), Ok((16511, 2)));
+    assert_eq!(decode(&[0x82, 0xFE, 0x7F]), Ok((65535, 3)));
+    assert_eq!(decode(&[0x8E, 0xFE, 0xFE, 0xFF, 0x00, ]), Ok((1 << 32, 5)));
+  }
+
+  #[test]
+  fn encoding_bip_samples() {
+    assert_eq!(encode(0), &[0x00]);
+    assert_eq!(encode(1), &[0x01]);
+    assert_eq!(encode(127), &[0x7F]);
+    assert_eq!(encode(128), &[0x80, 0x00]);
+    assert_eq!(encode(255), &[0x80, 0x7F]);
+    assert_eq!(encode(256), &[0x81, 0x00]);
+    assert_eq!(encode(16383), &[0xFE, 0x7F]);
+    assert_eq!(encode(16384), &[0xFF, 0x00]);
+    assert_eq!(encode(16511), &[0xFF, 0x7F]);
+    assert_eq!(encode(65535), &[0x82, 0xFE, 0x7F]);
+    assert_eq!(encode(1 << 32), &[0x8E, 0xFE, 0xFE, 0xFF, 0x00, ]);
+  }
 }


### PR DESCRIPTION
Add sample varint tests from Taproot Annex [BIP](https://github.com/bitcoin/bips/blob/9dc3f74b384f143b7f1bdad30dc0fe2529c8e63f/bip-annex.mediawiki#user-content-CompressedInt_Integer_Encoding)


```
 * 0:         [0x00]  256:        [0x81 0x00]
 * 1:         [0x01]  16383:      [0xFE 0x7F]
 * 127:       [0x7F]  16384:      [0xFF 0x00]
 * 128:  [0x80 0x00]  16511:      [0xFF 0x7F]
 * 255:  [0x80 0x7F]  65535: [0x82 0xFE 0x7F]
 * 2^32:           [0x8E 0xFE 0xFE 0xFF 0x00]
 ```