### PR TITLE
varint: improve encode/decode perf

### DIFF
--- a/src/varint.rs
+++ b/src/varint.rs
@@ -2,7 +2,8 @@ use super::*;
 
 #[cfg(test)]
 pub fn encode(mut n: u128) -> Vec<u8> {
-  let mut out = Vec::new();
+  // Pre allocate worst case 128/7 = ~18.3
+  let mut out = Vec::with_capacity(19);
 
   loop {
     let mut byte = n as u8 % 128;
@@ -38,7 +39,7 @@ pub fn decode(buffer: &[u8]) -> Result<(u128, usize)> {
 
     n += b - 127;
 
-    n = n.checked_mul(128).ok_or(Error::Varint)?;
+    n = n.checked_shl(7).ok_or(Error::Varint)?;
 
     i += 1;
   }

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -39,7 +39,11 @@ pub fn decode(buffer: &[u8]) -> Result<(u128, usize)> {
 
     n += b - 127;
 
-    n = n.checked_shl(7).ok_or(Error::Varint)?;
+    // check presence of any top 7 MSB that would indicate an overflow on the next shift
+    if n & (u128::MAX << 121) != 0 {
+      return Err(Error::Varint);
+    }
+    n <<= 7;
 
     i += 1;
   }


### PR DESCRIPTION
Encode: Pre allocating the output vec to the worst case of 19 bytes removes the need to re-allocate the vector with each additional push

Decode: Shift left by 7 bits rather than multiplying by 128 taking advantage `128 == 2^7`

| bench        | original (ns) | pre allocate (ns) | shift (ns) |
|--------------|---------------|-------------------|-----------|
| encode max   | 125           | 47                |           |
| encode mid   | 80            | 28                |           |
| encode small | 40            | 26                |           |
| decode max   | 6             |                   | 1         |
| decode mid   | 2             |                   | 1         |
| decode small | 1             |                   | 1         |


The difference is relatively minor on the order of nanoseconds especially in decode however when a future indexer may be decoding/encoding many records to perform an initial sync the difference can add up

Below are the basic benchmarks I used to validate the improvement however did not include them in the repo because they require using Rust nightly and enabling unstable features to use the `bench` feature

```rust
  use test::{Bencher, black_box};

  #[bench]
  fn benchmark_encode_max(b: &mut Bencher) {
    b.iter(|| encode(u128::MAX));
  }

  #[bench]
  fn benchmark_encode_mid(b: &mut Bencher) {
    b.iter(|| encode(u64::MAX as u128));
  }

  #[bench]
  fn benchmark_encode_small(b: &mut Bencher) {
    b.iter(|| encode(12345));
  }

  #[bench]
  fn benchmark_encode_pre_alloc_max(b: &mut Bencher) {
    b.iter(|| encode_pre_alloc(u128::MAX));
  }

  #[bench]
  fn benchmark_encode_pre_alloc_mid(b: &mut Bencher) {
    b.iter(|| encode_pre_alloc(u64::MAX as u128));
  }

  #[bench]
  fn benchmark_encode_pre_alloc_small(b: &mut Bencher) {
    b.iter(|| encode_pre_alloc(12345));
  }

  #[bench]
  fn benchmark_decode_small(b: &mut Bencher) {
    let input = &[223, 57];
    b.iter(|| black_box(decode(input)));
  }

  #[bench]
  fn benchmark_decode_mid(b: &mut Bencher) {
    let input = &[128, 254, 254, 254, 254, 254, 254, 254, 254, 127];
    b.iter(|| black_box(decode(input)));
  }

  #[bench]
  fn benchmark_decode_max(b: &mut Bencher) {
    let input = &[130, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 127];
    b.iter(|| black_box(decode(input)));
  }

  #[bench]
  fn benchmark_decode_shl_small(b: &mut Bencher) {
    let input = &[223, 57];
    b.iter(|| black_box(decode_shl(input)));
  }

  #[bench]
  fn benchmark_decode_shl_mid(b: &mut Bencher) {
    let input = &[128, 254, 254, 254, 254, 254, 254, 254, 254, 127];
    b.iter(|| black_box(decode_shl(input)));
  }

  #[bench]
  fn benchmark_decode_shl_max(b: &mut Bencher) {
    let input = &[130, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 127];
    b.iter(|| black_box(decode_shl(input)));
  }
```